### PR TITLE
chore: bump ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-scan.yml to v6.5.0

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -13,4 +13,4 @@ jobs:
     name: Container Scan
     permissions:
       contents: read
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-scan.yml@2ab174150aeb0a6003afd1c0b4316698720b3b6b # v5.5.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-scan.yml@12a73dc031fe7e355f2691a38bdfd190dc6983de # v6.5.0


### PR DESCRIPTION
Updates ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-scan.yml to pinned commit 12a73dc031fe7e355f2691a38bdfd190dc6983de (v6.5.0).