### PR TITLE
chore: bump analytical-platform-github-actions to v7.0.0

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -13,4 +13,4 @@ jobs:
     name: Container Scan
     permissions:
       contents: read
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-scan.yml@2ab174150aeb0a6003afd1c0b4316698720b3b6b # v5.5.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-scan.yml@22e533bbaa3a26bfa2fc3715b74daeba79d6300a # v7.0.0

--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -13,6 +13,6 @@ jobs:
     name: Scheduled Container Scan
     permissions:
       contents: read
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-scheduled-container-scan.yml@604db7bf80e5af74f8c081d47a406d293eeae029 # v2.1.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-scheduled-container-scan.yml@22e533bbaa3a26bfa2fc3715b74daeba79d6300a # v7.0.0
     secrets:
       cve-scan-slack-webhook-url: ${{ secrets.ANALYTICAL_PLATFORM_CVE_SCAN_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Updates the following to pinned commit 22e533bbaa3a26bfa2fc3715b74daeba79d6300a (v7.0.0):

- ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-scheduled-container-scan.yml
- ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-scan.yml